### PR TITLE
(Script/Translations) Modifying texts into multiple languages

### DIFF
--- a/conf/instance-reset.conf.dist
+++ b/conf/instance-reset.conf.dist
@@ -14,3 +14,5 @@ instanceReset.Enable=true
 #
 
 instanceReset.NormalModeOnly = false
+
+instanceResetAnnouncer.announceEnable = true

--- a/conf/instance-reset.conf.dist
+++ b/conf/instance-reset.conf.dist
@@ -15,4 +15,4 @@ instanceReset.Enable=true
 
 instanceReset.NormalModeOnly = false
 
-instanceResetAnnouncer.announceEnable = true
+instanceReset.Announcer = true

--- a/sql/world/base/npc_template.sql
+++ b/sql/world/base/npc_template.sql
@@ -10,7 +10,7 @@ DELETE FROM `creature_template` WHERE `entry` = @Entry;
 INSERT INTO `creature_template` (`entry`, `modelid1`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `unit_class`, `unit_flags`, `type`, `type_flags`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES
 (@Entry, @Model, @Name, @Title, "Speak", 0, 80, 80, 35, 0, 1, 1.14286, 1, 0, 1, 2, 7, 138936390, 1, 2, "instanceReset");
 
-UPDATE `creature_template` SET `npcflag`=`npcflag`|1 WHERE `entry`=@Entry;
+UPDATE `creature_template` SET `npcflag`=`npcflag`|1, `flags_extra`=`flags_extra`|16777216 WHERE `entry`=@Entry;
 
 DELETE FROM `creature_template_locale` WHERE `entry`=@Entry;
 

--- a/sql/world/base/npc_template.sql
+++ b/sql/world/base/npc_template.sql
@@ -1,4 +1,3 @@
--- NPC TEMPLATE FOR mod-instance-reset
 
 SET
 @Entry      := 300000,
@@ -6,7 +5,6 @@ SET
 @Name       := "Cromi",
 @Title      := "Instance Reset";
 
--- NPC
 DELETE FROM `creature_template` WHERE `entry` = @Entry;
 
 INSERT INTO `creature_template` (`entry`, `modelid1`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `unit_class`, `unit_flags`, `type`, `type_flags`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES
@@ -14,8 +12,14 @@ INSERT INTO `creature_template` (`entry`, `modelid1`, `name`, `subname`, `IconNa
 
 UPDATE `creature_template` SET `npcflag`=`npcflag`|1 WHERE `entry`=@Entry;
 
-DELETE FROM `creature_template_locale` WHERE `entry`=@Entry AND `locale` IN ('esES', 'esMX');
+DELETE FROM `creature_template_locale` WHERE `entry`=@Entry;
 
 INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
 (@Entry, 'esES', @Name, 'Reinicio de instancias', 0),
-(@Entry, 'esMX', @Name, 'Reinicio de instancias', 0);
+(@Entry, 'esMX', @Name, 'Reinicio de instancias', 0),
+(@Entry, 'frFR', @Name, 'Redémarrage des instances', 0),
+(@Entry, 'koKR', @Name, '인스턴스 재시작', 0),
+(@Entry, 'deDE', @Name, 'Neustart der Instanz', 0),
+(@Entry, 'zhCN', @Name, '重新启动实例', 0),
+(@Entry, 'zhTW', @Name, '實例重啟', 0),
+(@entry, 'ruRU', @name, 'Перезапуск подземелий', 0);

--- a/sql/world/base/npc_template.sql
+++ b/sql/world/base/npc_template.sql
@@ -1,10 +1,10 @@
 -- NPC TEMPLATE FOR mod-instance-reset
 
 SET
-@Entry 		:= 300000,
-@Model 		:= 24877,
-@Name 		:= "Cromi",
-@Title 		:= "Instance Reset";
+@Entry      := 300000,
+@Model      := 24877,
+@Name       := "Cromi",
+@Title      := "Instance Reset";
 
 -- NPC
 DELETE FROM `creature_template` WHERE `entry` = @Entry;
@@ -12,4 +12,10 @@ DELETE FROM `creature_template` WHERE `entry` = @Entry;
 INSERT INTO `creature_template` (`entry`, `modelid1`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `unit_class`, `unit_flags`, `type`, `type_flags`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES
 (@Entry, @Model, @Name, @Title, "Speak", 0, 80, 80, 35, 0, 1, 1.14286, 1, 0, 1, 2, 7, 138936390, 1, 2, "instanceReset");
 
--- TODO: add gossip text
+UPDATE `creature_template` SET `npcflag`=`npcflag`|1 WHERE `entry`=@Entry;
+
+DELETE FROM `creature_template_locale` WHERE `entry`=@Entry AND `locale` IN ('esES', 'esMX');
+
+INSERT INTO `creature_template_locale` (`entry`, `locale`, `Name`, `Title`, `VerifiedBuild`) VALUES
+(@Entry, 'esES', @Name, 'Reinicio de instancias', 0),
+(@Entry, 'esMX', @Name, 'Reinicio de instancias', 0);

--- a/sql/world/base/testing/creature.sql
+++ b/sql/world/base/testing/creature.sql
@@ -1,8 +1,0 @@
--- SPAWN THE INSTANCE RESET NPC (beware, it deletes existing entries) IN GM ISLAND
-
--- SET @INSTANCE_RESET_NPC := 999991;
-
--- DELETE FROM `creature` WHERE `id` = @1v1_NPC_ENTRY;
--- INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `dynamicflags`, `ScriptName`, `VerifiedBuild`) VALUES
--- (3130775,   @INSTANCE_RESET_NPC, 1,  0,  0,  1,  1,  0,  0,  16226.2,    16257,  13.2022,    1.65007,    300,    0,  0,  5074,   0,  0,  0,  0,  0,  '', 0);
-

--- a/src/InstanceReset.cpp
+++ b/src/InstanceReset.cpp
@@ -54,7 +54,6 @@ public:
                 {
                     message = "This server is running the |cff4CFF00Instance Reset |rmodule.";
                     break;
-
                 }
                 case LOCALE_esES:
                 case LOCALE_esMX:
@@ -66,8 +65,9 @@ public:
                 {
                     message = "Этот сервер использует модуль |cff4CFF00Перезапуск подземелий|r.";
                     break;
-
                 }
+                case TOTAL_LOCALES:
+                    break;
             }
             ChatHandler(player->GetSession()).SendSysMessage(message);
         }
@@ -108,7 +108,6 @@ public:
                     gossipText = "I would like to remove my instance saves.";
                     message = "Greetings $n. This is an npc that allows you to reset instance ids, allowing you to re-enter, without the need to wait for the reset time to expire. It was developed by the AzerothCore community.";
                     break;
-
                 }
                 case LOCALE_esES:
                 case LOCALE_esMX:
@@ -122,8 +121,9 @@ public:
                     gossipText = "Я бы хотел удалить мои сохраненные подземелья.";
                     message = "Приветствую, $n. Этот персонаж может удалить список посещенных подземелий, позволив Вам повторно их посетить не дожидаясь времени планового перезапуска. Разработан в AzerothCore community.";
                     break;
-
                 }
+                case TOTAL_LOCALES:
+                    break;
             }
             GossipSetText(player, message, DEFAULT_GOSSIP_MESSAGE);
             AddGossipItemFor(player, GOSSIP_ICON_CHAT, gossipText, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
@@ -178,6 +178,8 @@ public:
                     creatureWhisper = "Ваши подземелья перезагружены.";
                     break;
                 }
+                case TOTAL_LOCALES:
+                    break;
             }
             creature->Whisper(creatureWhisper, LANG_UNIVERSAL, player);
             CloseGossipMenuFor(player);

--- a/src/InstanceReset.cpp
+++ b/src/InstanceReset.cpp
@@ -40,7 +40,7 @@ public:
 
     void OnLogin(Player* player)
     {
-        if (sConfigMgr->GetOption<bool>("instanceResetAnnouncer.announceEnable", true))
+        if (sConfigMgr->GetOption<bool>("instanceReset.Announcer", true))
         {
             std::string message = "";
             switch (player->GetSession()->GetSessionDbLocaleIndex())
@@ -66,7 +66,7 @@ public:
                     message = "Этот сервер использует модуль |cff4CFF00Перезапуск подземелий|r.";
                     break;
                 }
-                case TOTAL_LOCALES:
+                default:
                     break;
             }
             ChatHandler(player->GetSession()).SendSysMessage(message);
@@ -122,7 +122,7 @@ public:
                     message = "Приветствую, $n. Этот персонаж может удалить список посещенных подземелий, позволив Вам повторно их посетить не дожидаясь времени планового перезапуска. Разработан в AzerothCore community.";
                     break;
                 }
-                case TOTAL_LOCALES:
+                default:
                     break;
             }
             GossipSetText(player, message, DEFAULT_GOSSIP_MESSAGE);
@@ -178,7 +178,7 @@ public:
                     creatureWhisper = "Ваши подземелья перезагружены.";
                     break;
                 }
-                case TOTAL_LOCALES:
+                default:
                     break;
             }
             creature->Whisper(creatureWhisper, LANG_UNIVERSAL, player);

--- a/src/InstanceReset.cpp
+++ b/src/InstanceReset.cpp
@@ -5,9 +5,70 @@
 #include "GossipDef.h"
 #include "ScriptedGossip.h"
 #include "Language.h"
+#include "Chat.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+#include "Opcodes.h"
 
 static bool instancereset_enable;
 static bool instancereset_normalmodeonly;
+
+void GossipSetText(Player* player, std::string message, uint32 textID)
+{
+    GossipText const* gossip = sObjectMgr->GetGossipText(textID);
+    WorldPacket data(SMSG_NPC_TEXT_UPDATE, 100);
+    data << textID;
+    for (uint8 i = 0; i < MAX_GOSSIP_TEXT_OPTIONS; ++i)
+    {
+        data << float(0);
+        data << message;
+        data << message;
+        data << uint32(0);
+        data << uint32(0);
+        data << uint32(0);
+        data << uint32(0);
+        data << uint32(0);
+        data << uint32(0);
+        data << uint32(0);
+    }
+    player->GetSession()->SendPacket(&data);
+}
+
+class InstanceResetAnnouncer : public PlayerScript
+{
+public:
+    InstanceResetAnnouncer() : PlayerScript("InstanceResetAnnouncer") {}
+
+    void OnLogin(Player* player)
+    {
+        if (sConfigMgr->GetOption<bool>("instanceResetAnnouncer.announceEnable", true))
+        {
+            std::string message = "";
+            switch (player->GetSession()->GetSessionDbLocaleIndex())
+            {
+                case LOCALE_enUS:
+                case LOCALE_koKR:
+                case LOCALE_frFR:
+                case LOCALE_deDE:
+                case LOCALE_zhCN:
+                case LOCALE_zhTW:
+                case LOCALE_ruRU:
+                {
+                    message = "This server is running the |cff4CFF00Instance Reset |rmodule.";
+                    break;
+
+                }
+                case LOCALE_esES:
+                case LOCALE_esMX:
+                {
+                    message = "Este servidor está ejecutando el módulo |cff4CFF00Instance reset|r";
+                    break;
+                }
+            }
+            ChatHandler(player->GetSession()).SendSysMessage(message);
+        }
+    }
+};
 
 class instanceResetConfigLoad : public WorldScript {
 public:
@@ -29,7 +90,33 @@ public:
     {
         if (instancereset_enable) {
             ClearGossipMenuFor(player);
-            AddGossipItemFor(player, GOSSIP_ICON_CHAT, "I would like to remove my instance saves.", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+            std::string gossipText = "";
+            std::string message = "";
+            switch (player->GetSession()->GetSessionDbLocaleIndex())
+            {
+                case LOCALE_enUS:
+                case LOCALE_koKR:
+                case LOCALE_frFR:
+                case LOCALE_deDE:
+                case LOCALE_zhCN:
+                case LOCALE_zhTW:
+                case LOCALE_ruRU:
+                {
+                    gossipText = "I would like to remove my instance saves.";
+                    message = "Greetings $n. This is an npc that allows you to reset instance ids, allowing you to re-enter, without the need to wait for the reset time to expire. It was developed by the AzerothCore community.";
+                    break;
+
+                }
+                case LOCALE_esES:
+                case LOCALE_esMX:
+                {
+                    gossipText = "Me gustaría reiniciar mis ids de instancias.";
+                    message = "Saludos $n. Este es un npc que te permite reiniciar los ids de las instancias, permitiéndote volver a entrar, sin la necesidad de esperar a que se cumpla el tiempo para el reinicio. Fue desarrollado por la comunidad de AzerothCore.";
+                    break;
+                }
+            }
+            GossipSetText(player, message, DEFAULT_GOSSIP_MESSAGE);
+            AddGossipItemFor(player, GOSSIP_ICON_CHAT, gossipText, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
             SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature->GetGUID());
         }
         return true;
@@ -57,7 +144,28 @@ public:
                         ++itr;
                 }
             }
-            creature->Whisper("Your instances have been reset.", LANG_UNIVERSAL, player);
+            std::string creatureWhisper = "";
+            switch (player->GetSession()->GetSessionDbLocaleIndex())
+            {
+                case LOCALE_enUS:
+                case LOCALE_koKR:
+                case LOCALE_frFR:
+                case LOCALE_deDE:
+                case LOCALE_zhCN:
+                case LOCALE_zhTW:
+                case LOCALE_ruRU:
+                {
+                    creatureWhisper = "Your instances have been reset.";
+                    break;
+                }
+                case LOCALE_esES:
+                case LOCALE_esMX:
+                {
+                    creatureWhisper = "Sus instancias han sido restablecidas.";
+                    break;
+                }
+            }
+            creature->Whisper(creatureWhisper, LANG_UNIVERSAL, player);
             CloseGossipMenuFor(player);
         }
         return true;
@@ -67,5 +175,5 @@ public:
 void AddInstanceResetScripts() {
     new instanceResetConfigLoad();
     new instanceReset();
+    new InstanceResetAnnouncer();
 }
-

--- a/src/InstanceReset.cpp
+++ b/src/InstanceReset.cpp
@@ -15,7 +15,6 @@ static bool instancereset_normalmodeonly;
 
 void GossipSetText(Player* player, std::string message, uint32 textID)
 {
-    GossipText const* gossip = sObjectMgr->GetGossipText(textID);
     WorldPacket data(SMSG_NPC_TEXT_UPDATE, 100);
     data << textID;
     for (uint8 i = 0; i < MAX_GOSSIP_TEXT_OPTIONS; ++i)

--- a/src/InstanceReset.cpp
+++ b/src/InstanceReset.cpp
@@ -51,7 +51,6 @@ public:
                 case LOCALE_deDE:
                 case LOCALE_zhCN:
                 case LOCALE_zhTW:
-                case LOCALE_ruRU:
                 {
                     message = "This server is running the |cff4CFF00Instance Reset |rmodule.";
                     break;
@@ -62,6 +61,12 @@ public:
                 {
                     message = "Este servidor está ejecutando el módulo |cff4CFF00Instance reset|r";
                     break;
+                }
+                case LOCALE_ruRU:
+                {
+                    message = "Этот сервер использует модуль |cff4CFF00Перезапуск подземелий|r.";
+                    break;
+
                 }
             }
             ChatHandler(player->GetSession()).SendSysMessage(message);
@@ -99,7 +104,6 @@ public:
                 case LOCALE_deDE:
                 case LOCALE_zhCN:
                 case LOCALE_zhTW:
-                case LOCALE_ruRU:
                 {
                     gossipText = "I would like to remove my instance saves.";
                     message = "Greetings $n. This is an npc that allows you to reset instance ids, allowing you to re-enter, without the need to wait for the reset time to expire. It was developed by the AzerothCore community.";
@@ -112,6 +116,13 @@ public:
                     gossipText = "Me gustaría reiniciar mis ids de instancias.";
                     message = "Saludos $n. Este es un npc que te permite reiniciar los ids de las instancias, permitiéndote volver a entrar, sin la necesidad de esperar a que se cumpla el tiempo para el reinicio. Fue desarrollado por la comunidad de AzerothCore.";
                     break;
+                }
+                case LOCALE_ruRU:
+                {
+                    gossipText = "Я бы хотел удалить мои сохраненные подземелья.";
+                    message = "Приветствую, $n. Этот персонаж может удалить список посещенных подземелий, позволив Вам повторно их посетить не дожидаясь времени планового перезапуска. Разработан в AzerothCore community.";
+                    break;
+
                 }
             }
             GossipSetText(player, message, DEFAULT_GOSSIP_MESSAGE);
@@ -152,7 +163,6 @@ public:
                 case LOCALE_deDE:
                 case LOCALE_zhCN:
                 case LOCALE_zhTW:
-                case LOCALE_ruRU:
                 {
                     creatureWhisper = "Your instances have been reset.";
                     break;
@@ -161,6 +171,11 @@ public:
                 case LOCALE_esMX:
                 {
                     creatureWhisper = "Sus instancias han sido restablecidas.";
+                    break;
+                }
+                case LOCALE_ruRU:
+                {
+                    creatureWhisper = "Ваши подземелья перезагружены.";
                     break;
                 }
             }


### PR DESCRIPTION
For some time now, I have been wanting to add translations to the modules. At one time, the idea was to add it in the database, but the problem with that, is that we would be adding content that is not blizzlike, since the modules are custom content. Thanks to the collaboration of several people, I managed to build this code, and I share it, so that you can tell me if it needs modifications, or if it can be applied in this way.

- The tests were performed on Windows 10.

The changes I propose are as follows:
- [x] Add a configuration variable, to let the players know that the module is present in the system.
- [x] Add the `npcflag` to 1, since in the last update of `creature_template`, it was set to 0, then the npc does not show any gossip by default.
- [x] Create a local method, which allows you to make an update of the npc_text, without the need to have it stored in the database, to give more information about the module and its use.
- [x] Add in `creature_template_locale` the translation of the `subname` of the npc.
- [x] I remove the testing script, because it generates comments when using the `db_assembler` and also, that SQL statement is probably not compatible with the current format.

If everything is correct, and you want to tell me the texts of the other missing languages, I can make a commit, add a new text and add a new language. These are the languages that would be missing:

- [x] LOCALE_enUS
- [ ] LOCALE_koKR
- [ ] LOCALE_frFR
- [ ] LOCALE_deDE
- [ ] LOCALE_zhCN
- [ ] LOCALE_zhTW
- [x] LOCALE_ruRU
- [x] LOCALE_esES
- [x] LOCALE_esMX  